### PR TITLE
AI strategies bravery and wargoal scores added for JAP and MUS

### DIFF
--- a/common/ai_strategies/00_default_strategy.txt
+++ b/common/ai_strategies/00_default_strategy.txt
@@ -318,6 +318,40 @@ ai_strategy_default = {
 			# add = 1
 		# }		
 
+		if = {
+			limit = {
+				has_journal_entry = je_muscovy_steppes_expansion
+				scope:target_country = {
+					any_scope_state = {
+						OR = {
+							state_region = s:STATE_DANU
+							state_region = s:STATE_ROSTOV
+							state_region = s:STATE_IDEL
+						}
+					}
+				}
+			}
+			add = 1
+		}	
+
+		if = {
+			limit = {
+				has_journal_entry = je_restore_order_korea
+				scope:target_country = {
+					any_scope_state = {
+						OR = {
+                            state_region = s:STATE_BUSAN
+                            state_region = s:STATE_YANGHO
+                            state_region = s:STATE_SEOUL
+                            state_region = s:STATE_PYONGYANG
+                            state_region = s:STATE_SARIWON
+						}
+					}
+				}
+			}
+			add = 1
+		}	
+
 		# # Ethiopian Thunderdome
 		# if = {
 			# limit = {
@@ -2165,6 +2199,36 @@ ai_strategy_default = {
 				# }
 				# add = 50
 			# }
+
+			if = {
+				limit = {
+					has_journal_entry = je_muscovy_steppes_expansion
+					scope:target_state = {
+						OR = {
+							state_region = s:STATE_DANU
+							state_region = s:STATE_ROSTOV
+							state_region = s:STATE_IDEL
+						}
+					}
+				}
+				add = 50
+			}
+
+			if = {
+				limit = {
+					has_journal_entry = je_restore_order_korea
+					scope:target_state = {
+						OR = {
+							state_region = s:STATE_BUSAN
+							state_region = s:STATE_YANGHO
+							state_region = s:STATE_SEOUL
+							state_region = s:STATE_PYONGYANG
+							state_region = s:STATE_SARIWON
+						}
+					}
+				}
+				add = 50
+			}
 			
 			if = {
 				limit = {


### PR DESCRIPTION
AI strategies bravery and wargoal scores added for Japan's Restore Order in Korea and Muscovy Steppes Expansion