### PR TITLE
Cleans up a redundant loc file

### DIFF
--- a/localization/english/dvg_government_l_english.yml
+++ b/localization/english/dvg_government_l_english.yml
@@ -1,5 +1,16 @@
 ﻿l_english:
+
+#Government Types
  gov_arch_kingdom:0 "Arch-Kingdom"
  gov_arch_kingdom_desc:1 "This is a [concept_government] form where the power rests with the [Concept('concept_ruler','$RULER_TITLE_ARCH-KING$')] or [Concept('concept_ruler','$RULER_TITLE_ARCH-QUEEN$')]."
+ gov_doge:0 "Merchant Republic"
+ gov_doge_desc:0 "A merchant republic with the Doge as the chief magistrate."
+ gov_viceroyalty:0 "Viceroyalty"
+ gov_viceroyalty_desc:0 "A viceroy in charge of colonial positions in the New World."
+
+
+#Ruler Titles
  RULER_TITLE_ARCH-KING: "Arch-King"
  RULER_TITLE_ARCH-QUEEN: "Arch-Queen"
+ RULER_TITLE_DOGE: "Doge"
+ RULER_TITLE_VICEROY: "Viceroy"

--- a/localization/english/dvg_politics_l_english.yml
+++ b/localization/english/dvg_politics_l_english.yml
@@ -1,7 +1,0 @@
-﻿l_english:
- gov_doge:0 "Merchant Republic"
- gov_doge_desc:0 "A merchant republic with the Doge as the chief magistrate."
- RULER_TITLE_DOGE:0 "Doge"
- gov_viceroyalty:0 "Viceroyalty"
- gov_viceroyalty_desc:0 "A viceroy in charge of colonial positions in the new world."
- RULER_TITLE_VICEROY:0 "Viceroy"


### PR DESCRIPTION
Removes dvg_politics_l_english.yml and moves the definitions to dvg_government_l_english.yml, where the existing government types already are, and where those things are located in vanilla.