### PR TITLE
SGF formable fix

### DIFF
--- a/common/country_definitions/dvg_europe.txt
+++ b/common/country_definitions/dvg_europe.txt
@@ -542,7 +542,7 @@ SGF = { #Danubian Confederation
 	
 	country_type = recognized
 
-	tier = kingdom
+	tier = empire
 
 	cultures = { south_german }
 	capital = STATE_BAVARIA

--- a/common/country_formation/dvg_formables_europe.txt
+++ b/common/country_formation/dvg_formables_europe.txt
@@ -85,11 +85,22 @@ NGF = { #League of Berlin
 }
 
 SGF = { #Danubian Confederation
-	use_culture_states = yes
-
+	states = {
+		STATE_BAVARIA
+		STATE_TYROL
+		STATE_AUSTRIA
+		STATE_STYRIA
+		STATE_SLOVENIA
+		STATE_EAST_SWITZERLAND
+		STATE_WEST_SWITZERLAND
+		STATE_BADEN
+		STATE_WURTTEMBERG
+		STATE_FRANCONIA
+	}
 	required_states_fraction = 0.75
 
 	possible = {
+		country_has_primary_culture = cu:south_german
 		has_technology_researched = nationalism
 	}
 	

--- a/common/flag_definitions/00_flag_definitions.txt
+++ b/common/flag_definitions/00_flag_definitions.txt
@@ -7414,27 +7414,27 @@ SGF = { # South German Federation DVG
 			coa_def_republic_flag_trigger = yes
 		}
 	}
-	# flag_definition = {
-		# coa = SGF
-		# subject_canton = SGF
-		# priority = 1
-	# }
-	# flag_definition = {
-		# coa = SGF_republic
-		# subject_canton = SGF_republic
-		# priority = 10
-		# trigger = { 
-			# coa_def_republic_flag_trigger = yes
-		# }
-	# }	
-	# flag_definition = {
-		# coa = SGF_fascist
-		# subject_canton = SGF_fascist
-		# priority = 1500
-		# trigger = { 
-			# coa_def_fascist_flag_trigger = yes
-		# }
-	# }	
+	flag_definition = {
+		coa = SGF
+		subject_canton = SGF
+		priority = 1
+	}
+	flag_definition = {
+		coa = SGF_republic
+		subject_canton = SGF_republic
+		priority = 10
+		trigger = { 
+			coa_def_republic_flag_trigger = yes
+		}
+	}	
+	flag_definition = {
+		coa = SGF_fascist
+		subject_canton = SGF_fascist
+		priority = 1500
+		trigger = { 
+			coa_def_fascist_flag_trigger = yes
+		}
+	}	
 }
 
 SIA = { # Siam


### PR DESCRIPTION
Makes Danubian Confederation formable by all Danubian states (Bavaria and Austria previously excluded due to the arbitrary title ranks of tags)

Border edits to match DoD Danubian Confederation (placeholder until reworked)