### PR TITLE
Green Prince fix for when TVE or MSO is dead

### DIFF
--- a/common/history/diplomacy/00_relations.txt
+++ b/common/history/diplomacy/00_relations.txt
@@ -135,9 +135,11 @@
 	c:MSO = {
 		set_relations = { country = c:POL value = 50 }
 		set_relations = { country = c:NZH value = 50 }
+		set_relations = { country = c:TVE value = 50 }
 	}
 	c:TVE = {
 		set_relations = { country = c:NZH value = 50 }
+		set_relations = { country = c:MSO value = 50 }
 	}
 	c:NZH = {
 		set_relations = { country = c:TVE value = 50 }

--- a/common/history/trade_routes/dvg_trade_routes.txt
+++ b/common/history/trade_routes/dvg_trade_routes.txt
@@ -1541,7 +1541,7 @@
 		}
 		create_trade_route = {
 			goods = fabric
-			level = 6
+			level = 4
 			direction = export
 			target = c:DUA.market
 		}

--- a/common/journal_entries/dvg_rus_green_prince.txt
+++ b/common/journal_entries/dvg_rus_green_prince.txt
@@ -1,7 +1,7 @@
 ﻿je_rus_green_prince_nzh = {
 	icon = "gfx/interface/icons/event_icons/event_military.dds"
 
-    status_desc = {
+	status_desc = {
 		first_valid = {
 			triggered_desc = {
 				desc = rus_green_prince_step_1
@@ -19,36 +19,36 @@
 	}
 
 	complete = {
-        OR = {
-            custom_tooltip = {
-                text = green_prince_heir
-                any_scope_character = {
-                    is_heir = yes
-                }
-            }
-        }
+		OR = {
+			custom_tooltip = {
+				text = green_prince_heir
+				any_scope_character = {
+					is_heir = yes
+				}
+			}
+		}
 	}	
-    
-    on_complete = {
-        add_journal_entry = {
-            type = je_rus_green_prince_resolve
-        }
+	
+	on_complete = {
+		add_journal_entry = {
+			type = je_rus_green_prince_resolve
+		}
 	}
-    
-    invalid = {
+	
+	invalid = {
 		OR = {
 			NOT = {
 				exists = c:NZH
 			}
-            custom_tooltip = {
-                text = green_prince_died
-                ruler = {
-                    NOT = { has_variable = is_green_prince }
-                }
-            }
-            year >= 1843
-        }
-    }     
+			custom_tooltip = {
+				text = green_prince_died
+				ruler = {
+					NOT = { has_variable = is_green_prince }
+				}
+			}
+			year >= 1843
+		}
+	}     
 
 	weight = 10
 	should_be_pinned_by_default = yes
@@ -57,104 +57,104 @@
 je_rus_green_prince = {
 	icon = "gfx/interface/icons/event_icons/event_military.dds"
 
-    status_desc = {
+	status_desc = {
 		first_valid = {
 			triggered_desc = {
 				desc = rus_green_prince_step_1
 				trigger = {
-                    exists = c:NZH
-                    c:NZH = {
-					    NOT = { has_variable = gay_green_prince }
-                    }
+					exists = c:NZH
+					c:NZH = {
+						NOT = { has_variable = gay_green_prince }
+					}
 				}
 			}
 			triggered_desc = {
 				desc = rus_green_prince_step_2
-                trigger = {
-                    exists = c:NZH
-                    c:NZH = {
-                        has_variable = gay_green_prince
-                    }
-                }
+				trigger = {
+					exists = c:NZH
+					c:NZH = {
+						has_variable = gay_green_prince
+					}
+				}
 			}
 		}
 	}
 
-    complete = {
-        exists = c:NZH
+	complete = {
+		exists = c:NZH
 		c:NZH = {
-            custom_tooltip = {
-                text = green_prince_heir
-                any_scope_character = {
-                    is_heir = yes
-                }
-            }
-        }
+			custom_tooltip = {
+				text = green_prince_heir
+				any_scope_character = {
+					is_heir = yes
+				}
+			}
+		}
 	}	
-    
-    on_complete = {
-        add_journal_entry = {
-            type = je_rus_green_prince_resolve
-        }
+	
+	on_complete = {
+		add_journal_entry = {
+			type = je_rus_green_prince_resolve
+		}
 	}
 
-    invalid = {
+	invalid = {
 		OR = {
 			NOT = {
 				exists = c:NZH
 			}
-            c:NZH = {
-                custom_tooltip = {
-                    text = green_prince_died
-                    ruler = {
-                        NOT = { has_variable = is_green_prince }
-                    }
-                }
-            }
-            year >= 1843
-        }
-    }     
+			c:NZH = {
+				custom_tooltip = {
+					text = green_prince_died
+					ruler = {
+						NOT = { has_variable = is_green_prince }
+					}
+				}
+			}
+			year >= 1843
+		}
+	}     
 
 	weight = 10
 	should_be_pinned_by_default = yes
 }
 
 je_rus_green_prince_resolve = {
-    icon = "gfx/interface/icons/event_icons/event_military.dds"
+	icon = "gfx/interface/icons/event_icons/event_military.dds"
 
-    status_desc = {
+	status_desc = {
 		first_valid = {
-            triggered_desc = {
+			triggered_desc = {
 				desc = rus_green_prince_resolve_step_3
-                trigger = {
-                    exists = c:NZH
-                    c:NZH = {
-					    has_variable = nzh_crisis_three
-                    }
+				trigger = {
+					exists = c:NZH
+					c:NZH = {
+						has_variable = nzh_crisis_three
+					}
 				}
 			}
 			triggered_desc = {
 				desc = rus_green_prince_resolve_step_1
 				trigger = {
-                    exists = c:NZH
-                    c:NZH = {
-					    NOT = { has_variable = nzh_crisis_two }
-                    }
+					exists = c:NZH
+					c:NZH = {
+						NOT = { has_variable = nzh_crisis_two }
+					}
 				}
 			}
 			triggered_desc = {
 				desc = rus_green_prince_resolve_step_2
-                trigger = {
-                    exists = c:NZH
-                    c:NZH = {
-					    has_variable = nzh_crisis_two
-                    }
+				trigger = {
+					exists = c:NZH
+					c:NZH = {
+						has_variable = nzh_crisis_two
+					}
 				}
 			}
-            triggered_desc = {
+			triggered_desc = {
 				desc = rus_green_prince_resolve_step_end
-                trigger = {
-                    NOT = { exists = c:NZH }
+				trigger = {
+					NOT = { exists = c:NZH }
 				}
 			}
 		}
@@ -162,42 +162,42 @@ je_rus_green_prince_resolve = {
 
 	# note that if you change this, also update the decision
 	complete = {
-        custom_tooltip = {
-            text = green_prince_resolved
-            OR = {
-                AND = {
-                    exists = c:MSO
-                    root = c:MSO
-                    NOT = { exists = c:TVE }
-                    NOT = { exists = c:NZH }
-                }
-                AND = {
-                    exists = c:TVE
-                    root = c:TVE
-                    NOT = { exists = c:MSO }
-                    NOT = { exists = c:NZH }
-                }
-            }
-        }
+		custom_tooltip = {
+			text = green_prince_resolved
+			OR = {
+				AND = {
+					exists = c:MSO
+					root = c:MSO
+					NOT = { exists = c:TVE }
+					NOT = { exists = c:NZH }
+				}
+				AND = {
+					exists = c:TVE
+					root = c:TVE
+					NOT = { exists = c:MSO }
+					NOT = { exists = c:NZH }
+				}
+			}
+		}
 	}
-    
-    on_complete = {
+	
+	on_complete = {
 	}
 
-    invalid = {
+	invalid = {
 		OR = {
 			NOT = {
 				exists = c:NZH
 			}
-            NOT = {
+			NOT = {
 				exists = c:TVE
 			}
-            NOT = {
+			NOT = {
 				exists = c:MSO
 			}
-        }
-    }     
+		}
+	}     
 
-    weight = 10
+	weight = 10
 	should_be_pinned_by_default = yes
 }

--- a/common/journal_entries/dvg_rus_green_prince.txt
+++ b/common/journal_entries/dvg_rus_green_prince.txt
@@ -184,6 +184,20 @@ je_rus_green_prince_resolve = {
     on_complete = {
 	}
 
+    invalid = {
+		OR = {
+			NOT = {
+				exists = c:NZH
+			}
+            NOT = {
+				exists = c:TVE
+			}
+            NOT = {
+				exists = c:MSO
+			}
+        }
+    }     
+
     weight = 10
 	should_be_pinned_by_default = yes
 }

--- a/events/dvg_spanish_events.txt
+++ b/events/dvg_spanish_events.txt
@@ -1724,12 +1724,30 @@ dvg_spain.25 = {
 
 	trigger = {
 		OR = {
-			c:MEX = ROOT
-			c:UCA = ROOT
-			c:GCO = ROOT
-			c:GRA = ROOT
-			c:QUI = ROOT
-			c:LUS = ROOT
+			AND = {
+				exists = c:MEX
+				c:MEX = ROOT
+			}
+			AND = {
+				exists = c:UCA
+				c:UCA = ROOT
+			}
+			AND = {
+				exists = c:GCO
+				c:GCO = ROOT
+			}
+			AND = {
+				exists = c:GRA
+				c:GRA = ROOT
+			}
+			AND = {
+				exists = c:QUI
+				c:QUI = ROOT
+			}
+			AND = {
+				exists = c:LUS
+				c:LUS = ROOT
+			}
 		}
 		is_subject_of = c:SPA
 		NOT = { 

--- a/events/russia/dvg_green_prince.txt
+++ b/events/russia/dvg_green_prince.txt
@@ -307,7 +307,7 @@ dvg_green_prince_events.21 = {
 	}
 
 	immediate = {
-	    set_variable = {
+		set_variable = {
 			name = nzh_crisis_two
 		}
 	}
@@ -372,7 +372,7 @@ dvg_green_prince_events.22 = {
 	duration = 3
 
 	immediate = {
-	    set_variable = {
+		set_variable = {
 			name = nzh_crisis_three
 		}
 	}
@@ -544,7 +544,7 @@ dvg_green_prince_events.31 = {
 	}
 
 	immediate = {
-	    set_variable = {
+		set_variable = {
 			name = nzh_crisis_two
 		}
 		ruler = {
@@ -703,7 +703,7 @@ dvg_green_prince_events.41 = {
 	}
 
 	immediate = {
-	    set_variable = {
+		set_variable = {
 			name = nzh_crisis_two
 		}
 	}
@@ -750,7 +750,7 @@ dvg_green_prince_events.42 = {
 	duration = 3
 
 	immediate = {
-	    set_variable = {
+		set_variable = {
 			name = nzh_crisis_three
 		}
 		random_scope_character = {
@@ -812,7 +812,7 @@ dvg_green_prince_events.43 = {
 	duration = 3
 
 	immediate = {
-	    set_variable = {
+		set_variable = {
 			name = nzh_crisis_three
 		}
 		ruler = {
@@ -957,7 +957,7 @@ dvg_green_prince_events.51 = {
 	}
 
 	immediate = {
-	    set_variable = {
+		set_variable = {
 			name = nzh_crisis_two
 		}
 		random_scope_character = {

--- a/events/russia/dvg_green_prince.txt
+++ b/events/russia/dvg_green_prince.txt
@@ -121,18 +121,28 @@ dvg_green_prince_events.3 = {
 		name = dvg_green_prince_events.3.a
 		default_option = yes
 
-		c:TVE ={
-			trigger_event = {
-				id = dvg_green_prince_events.11
-				days = 3
-				popup = yes
+		if = {
+			limit = {
+				exists = c:TVE
+			}
+			c:TVE ={
+				trigger_event = {
+					id = dvg_green_prince_events.11
+					days = 3
+					popup = yes
+				}
 			}
 		}
-		c:MSO ={
-			trigger_event = {
-				id = dvg_green_prince_events.12
-				days = 6
-				popup = yes
+		if = {
+			limit = {
+				exists = c:MSO
+			}
+			c:MSO ={
+				trigger_event = {
+					id = dvg_green_prince_events.12
+					days = 6
+					popup = yes
+				}
 			}
 		}
 	}


### PR DESCRIPTION
-If TVE or MSO is dead, the green prince will continue until the heir is born. If one of then does not exist, there will be no crisis and war. The journal will cancel.
- TVE and MSO starts with relation boost at start. This avoids them able to declare war on each other for a while.
- Fixing some errors with Spanish event
- Fixing trade route EGY to DUA